### PR TITLE
[AD-469] Add player vendor.

### DIFF
--- a/modules/spotxBidAdapter.js
+++ b/modules/spotxBidAdapter.js
@@ -83,6 +83,7 @@ export const spec = {
 
       const ext = {
         sdk_name: 'Prebid 1+',
+        player_vendor: 'SpotXJW',
         versionOrtb: ORTB_VERSION
       };
 


### PR DESCRIPTION
Prebid.js' SpotX adapter doesn't send `player_vendor`. We rely on this key and value `SpotXJW` for our analytics.

This PR adds this back in - but only in this fork (not upstream).