### PR TITLE
[AD-1499] Integrate Video Module with Ad Server

### DIFF
--- a/modules/gamAdServerSubmodule.js
+++ b/modules/gamAdServerSubmodule.js
@@ -1,6 +1,5 @@
-import { GAM_VENDOR } from './videoModule/constants/vendorCodes';
-import { adServerDirectory } from './videoModule/vendorDirectory';
-
+import { GAM_VENDOR } from './videoModule/constants/vendorCodes.js';
+import { adServerDirectory } from './videoModule/vendorDirectory.js';
 
 function GamAdServerProvider(dfpModule_) {
   const dfp = dfpModule_;

--- a/modules/gamAdServerSubmodule.js
+++ b/modules/gamAdServerSubmodule.js
@@ -1,8 +1,23 @@
+import { GAM_VENDOR } from './videoModule/constants/vendorCodes';
+import { adServerDirectory } from './videoModule/vendorDirectory';
 
-function gamAdServerSubmodule() {
+
+function GamAdServerProvider(dfpModule_) {
+  const dfp = dfpModule_;
 
   function getAdTagUrl(adUnit, baseAdTag) {
-    // engine.adServers.dfp
     return dfp.buildVideoUrl({ adUnit: adUnit, url: baseAdTag });
   }
+
+  return {
+    getAdTagUrl
+  }
 }
+function gamSubmoduleFactory() {
+  const dfp = $$PREBID_GLOBAL$$.adServers.dfp;
+  const gamProvider = GamAdServerProvider(dfp);
+  return gamProvider;
+}
+
+gamSubmoduleFactory.vendorCode = GAM_VENDOR;
+adServerDirectory[GAM_VENDOR] = gamSubmoduleFactory;

--- a/modules/gamAdServerSubmodule.js
+++ b/modules/gamAdServerSubmodule.js
@@ -1,0 +1,8 @@
+
+function gamAdServerSubmodule() {
+
+  function getAdTagUrl(adUnit, baseAdTag) {
+    // engine.adServers.dfp
+    return dfp.buildVideoUrl({ adUnit: adUnit, url: baseAdTag });
+  }
+}

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -124,11 +124,11 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
     }
   }
 
-  function setAdTagUrl(adTagUrl, adXml) {
+  function setAdTagUrl(adTagUrl, options) {
     if (!player) {
       return;
     }
-    player.playAd(adTagUrl || adXml);
+    player.playAd(adTagUrl || options.adXml, options);
   }
 
   function onEvents(events, callback) {

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -9,7 +9,7 @@ import {
 } from './videoModule/constants/events.js';
 import stateFactory from './videoModule/shared/state.js';
 import { JWPLAYER_VENDOR } from './videoModule/constants/vendorCodes.js';
-import { vendorDirectory } from './videoModule/vendorDirectory.js';
+import { videoVendorDirectory } from './videoModule/vendorDirectory.js';
 
 export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callbackStorage_, utils) {
   const jwplayer = jwplayer_;
@@ -632,7 +632,7 @@ const jwplayerSubmoduleFactory = function (config) {
 }
 
 jwplayerSubmoduleFactory.vendorCode = JWPLAYER_VENDOR;
-vendorDirectory[JWPLAYER_VENDOR] = jwplayerSubmoduleFactory;
+videoVendorDirectory[JWPLAYER_VENDOR] = jwplayerSubmoduleFactory;
 export default jwplayerSubmoduleFactory;
 
 // HELPERS

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -124,11 +124,11 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
     }
   }
 
-  function setAdTagUrl(adTagUrl) {
+  function setAdTagUrl(adTagUrl, adXml) {
     if (!player) {
       return;
     }
-    player.playAd(adTagUrl);
+    player.playAd(adTagUrl || adXml);
   }
 
   function onEvents(events, callback) {

--- a/modules/videoModule/adServer.js
+++ b/modules/videoModule/adServer.js
@@ -5,11 +5,12 @@ export function AdServerCore(parentModule_) {
   const parentModule = parentModule_;
 
   function registerAdServer(config) {
-    parentModule.registerSubmodule(config.vendorCode, config.params);
+    const vendorCode = config.vendorCode;
+    parentModule.registerSubmodule(vendorCode, vendorCode, config);
   }
 
   function getAdTagUrl(vendorCode) {
-    const submodule = parentModule.getSudmodule(vendorCode);
+    const submodule = parentModule.getSubmodule(vendorCode);
     return submodule && submodule.getAdTagUrl();
   }
 

--- a/modules/videoModule/adServer.js
+++ b/modules/videoModule/adServer.js
@@ -9,9 +9,9 @@ export function AdServerCore(parentModule_) {
     parentModule.registerSubmodule(vendorCode, vendorCode, config);
   }
 
-  function getAdTagUrl(vendorCode) {
+  function getAdTagUrl(vendorCode, adUnit, baseAdTagUrl) {
     const submodule = parentModule.getSubmodule(vendorCode);
-    return submodule && submodule.getAdTagUrl();
+    return submodule && submodule.getAdTagUrl(adUnit, baseAdTagUrl);
   }
 
   return {

--- a/modules/videoModule/adServer.js
+++ b/modules/videoModule/adServer.js
@@ -1,0 +1,9 @@
+export function AdServerCore() {
+  function registerProvider(vendorCode, params) {
+
+  }
+
+  function getAdTagUrl() {
+
+  }
+}

--- a/modules/videoModule/adServer.js
+++ b/modules/videoModule/adServer.js
@@ -1,9 +1,27 @@
-export function AdServerCore() {
-  function registerProvider(vendorCode, params) {
+import { adServerDirectory } from './vendorDirectory.js';
+import { ParentModule, submoduleBuilder } from './shared/parentModule';
 
+export function AdServerCore(parentModule_) {
+  const parentModule = parentModule_;
+
+  function registerAdServer(config) {
+    parentModule.registerSubmodule(config.vendorCode, config.params);
   }
 
-  function getAdTagUrl() {
-
+  function getAdTagUrl(vendorCode) {
+    const submodule = parentModule.getSudmodule(vendorCode);
+    return submodule && submodule.getAdTagUrl();
   }
+
+  return {
+    registerAdServer,
+    getAdTagUrl
+  }
+}
+
+export function coreAdServerFactory() {
+  const adServerSubmoduleBuilder = submoduleBuilder(adServerDirectory);
+  const parentModule = ParentModule(adServerSubmoduleBuilder);
+  const adServerCore = AdServerCore(parentModule);
+  return adServerCore;
 }

--- a/modules/videoModule/adServer.js
+++ b/modules/videoModule/adServer.js
@@ -1,5 +1,5 @@
 import { adServerDirectory } from './vendorDirectory.js';
-import { ParentModule, submoduleBuilder } from './shared/parentModule';
+import { ParentModule, SubmoduleBuilder } from './shared/parentModule.js';
 
 export function AdServerCore(parentModule_) {
   const parentModule = parentModule_;
@@ -20,7 +20,7 @@ export function AdServerCore(parentModule_) {
 }
 
 export function coreAdServerFactory() {
-  const adServerSubmoduleBuilder = submoduleBuilder(adServerDirectory);
+  const adServerSubmoduleBuilder = SubmoduleBuilder(adServerDirectory);
   const parentModule = ParentModule(adServerSubmoduleBuilder);
   const adServerCore = AdServerCore(parentModule);
   return adServerCore;

--- a/modules/videoModule/constants/vendorCodes.js
+++ b/modules/videoModule/constants/vendorCodes.js
@@ -1,2 +1,6 @@
+// Video Vendors
 export const JWPLAYER_VENDOR = 1;
 export const VIDEO_JS_VENDOR = 2;
+
+// Ad Server Vendors
+export const GAM_VENDOR = 'gam';

--- a/modules/videoModule/coreVideo.js
+++ b/modules/videoModule/coreVideo.js
@@ -13,9 +13,9 @@ export function VideoCore(parentModule_) {
     return submodule && submodule.getOrtbParams();
   }
 
-  function setAdTagUrl(adTagUrl, divId) {
+  function setAdTagUrl(adTagUrl, divId, adXml) {
     const submodule = parentModule.getSubmodule(divId);
-    return submodule && submodule.setAdTagUrl(adTagUrl);
+    return submodule && submodule.setAdTagUrl(adTagUrl, adXml);
   }
 
   function onEvents(events, callback, divId) {

--- a/modules/videoModule/coreVideo.js
+++ b/modules/videoModule/coreVideo.js
@@ -13,9 +13,9 @@ export function VideoCore(parentModule_) {
     return submodule && submodule.getOrtbParams();
   }
 
-  function setAdTagUrl(adTagUrl, divId, adXml) {
+  function setAdTagUrl(adTagUrl, divId, options) {
     const submodule = parentModule.getSubmodule(divId);
-    return submodule && submodule.setAdTagUrl(adTagUrl, adXml);
+    return submodule && submodule.setAdTagUrl(adTagUrl, options);
   }
 
   function onEvents(events, callback, divId) {

--- a/modules/videoModule/coreVideo.js
+++ b/modules/videoModule/coreVideo.js
@@ -1,41 +1,30 @@
-import { vendorDirectory } from './vendorDirectory.js';
+import { videoVendorDirectory } from './vendorDirectory.js';
+import { ParentModule, submoduleBuilder } from './shared/parentModule';
 
-export function VideoCore(submoduleBuilder_) {
-  const submodules = {};
-  const submoduleBuilder = submoduleBuilder_;
+export function VideoCore(parentModule_) {
+  const parentModule = parentModule_;
 
   function registerProvider(providerConfig) {
-    const divId = providerConfig.divId;
-    if (submodules[divId]) {
-      return;
-    }
-
-    let submodule;
-    try {
-      submodule = submoduleBuilder.build(providerConfig);
-    } catch (e) {
-      throw e;
-    }
-    submodules[divId] = submodule;
+    parentModule.registerSubmodule(providerConfig.divId, providerConfig);
   }
 
   function getOrtbParams(divId) {
-    const submodule = submodules[divId];
+    const submodule = parentModule.getSubmodule(divId);
     return submodule && submodule.getOrtbParams();
   }
 
   function setAdTagUrl(adTagUrl, divId) {
-    const submodule = submodules[divId];
+    const submodule = parentModule.getSubmodule(divId);
     return submodule && submodule.setAdTagUrl(adTagUrl);
   }
 
   function onEvents(events, callback, divId) {
-    const submodule = submodules[divId];
+    const submodule = parentModule.getSubmodule(divId);
     return submodule && submodule.onEvents(events, callback);
   }
 
   function offEvents(events, callback, divId) {
-    const submodule = submodules[divId];
+    const submodule = parentModule.getSubmodule(divId);
     return submodule && submodule.offEvents(events, callback);
   }
 
@@ -49,25 +38,7 @@ export function VideoCore(submoduleBuilder_) {
 }
 
 export function videoCoreFactory() {
-  const submoduleBuilder = VideoSubmoduleBuilder(vendorDirectory);
-  return VideoCore(submoduleBuilder);
-}
-
-export function VideoSubmoduleBuilder(vendorDirectory_) {
-  const vendorDirectory = vendorDirectory_;
-
-  function build(providerConfig) {
-    const submoduleFactory = vendorDirectory[providerConfig.vendorCode];
-    if (!submoduleFactory) {
-      throw new Error('Unrecognized vendor code');
-    }
-
-    const submodule = submoduleFactory(providerConfig);
-    submodule && submodule.init && submodule.init();
-    return submodule;
-  }
-
-  return {
-    build
-  };
+  const videoSubmoduleBuilder = submoduleBuilder(videoVendorDirectory);
+  const parentModule = ParentModule(videoSubmoduleBuilder);
+  return VideoCore(parentModule);
 }

--- a/modules/videoModule/coreVideo.js
+++ b/modules/videoModule/coreVideo.js
@@ -1,5 +1,5 @@
 import { videoVendorDirectory } from './vendorDirectory.js';
-import { ParentModule, submoduleBuilder } from './shared/parentModule';
+import { ParentModule, SubmoduleBuilder } from './shared/parentModule.js';
 
 export function VideoCore(parentModule_) {
   const parentModule = parentModule_;
@@ -38,7 +38,7 @@ export function VideoCore(parentModule_) {
 }
 
 export function videoCoreFactory() {
-  const videoSubmoduleBuilder = submoduleBuilder(videoVendorDirectory);
+  const videoSubmoduleBuilder = SubmoduleBuilder(videoVendorDirectory);
   const parentModule = ParentModule(videoSubmoduleBuilder);
   return VideoCore(parentModule);
 }

--- a/modules/videoModule/coreVideo.js
+++ b/modules/videoModule/coreVideo.js
@@ -5,7 +5,7 @@ export function VideoCore(parentModule_) {
   const parentModule = parentModule_;
 
   function registerProvider(providerConfig) {
-    parentModule.registerSubmodule(providerConfig.divId, providerConfig);
+    parentModule.registerSubmodule(providerConfig.divId, providerConfig.vendorCode, providerConfig);
   }
 
   function getOrtbParams(divId) {

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -35,11 +35,31 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
 
     requestBids.before(enrichAdUnits, 40);
 
+    /*
+    auction result conforms to:
+    {
+      auctionId: _auctionId,
+      timestamp: _auctionStart,
+      auctionEnd: _auctionEnd,
+      auctionStatus: _auctionStatus,
+      adUnits: _adUnits,
+      adUnitCodes: _adUnitCodes,
+      labels: _labels,
+      bidderRequests: _bidderRequests,
+      noBids: _noBids,
+      bidsReceived: _bidsReceived,
+      winningBids: _winningBids,
+      timeout: _timeout
+    }
+     */
     pbEvents.on(CONSTANTS.EVENTS.AUCTION_END, function(auctionResult) {
       // TODO: requires AdServer Module.
-      // get ad tag from adServer - auctionResult.winningBids
-      // coreVideo.setAdTagUrl(adTag, divId);
-      // const adTagUrl = adServerCore.getAdTagUrl();
+      console.log(auctionResult);
+      auctionResult.adUnits.forEach(adUnit => {
+        if (adUnit.video) {
+          renderWinningBid(adUnit);
+        }
+      });
     });
   }
 
@@ -50,6 +70,31 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
       adUnit.mediaTypes.video = Object.assign({}, adUnit.mediaTypes.video, oRtbParams);
     });
     return nextFn.call(this, bidRequest);
+  }
+
+  function renderWinningBid(adUnit) {
+    const videoConfig = adUnit.video;
+    const divId = videoConfig.divId;
+    const adServerConfig = videoConfig.adServer;
+    let adTagUrl;
+    if (adServerConfig) {
+      adTagUrl = adServerCore.getAdTagUrl(adServerConfig.vendorCode, adUnit, adServerConfig.baseAdTagUrl);
+    }
+
+    if (adTagUrl) {
+      videoCore.setAdTagUrl(adTagUrl, divId);
+      return;
+    }
+
+    const highestCpmBids = pbGlobal.getHighestCpmBids(adUnit.code);
+    const highestBid = highestCpmBids && highestCpmBids.shift();
+    if (!highestBid) {
+      return;
+    }
+
+    adTagUrl = highestBid.vastUrl;
+    let adXml = highestBid.vastXml;
+    videoCore.setAdTagUrl(adTagUrl, divId, adXml);
   }
 
   return { init };

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -6,13 +6,14 @@ import { videoCoreFactory } from './coreVideo.js';
 
 events.addEvents(allVideoEvents);
 
-export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvents_) {
+export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvents_, adServerCore_) {
   const videoCore = videoCore_;
   const getConfig = getConfig_;
   const pbGlobal = pbGlobal_;
   const requestBids = pbGlobal.requestBids;
   const pbEvents = pbEvents_;
   const videoEvents = videoEvents_;
+  const adServerCore = adServerCore_;
 
   function init() {
     getConfig('video', ({ video }) => {
@@ -23,7 +24,15 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
             pbEvents.emit(type, payload);
           }, provider.divId);
         } catch (e) {}
+
+        const adServerConfig = provider.adServer;
+        if (adServerConfig) {
+          adServerCore.registerProvider(adServerConfig.vendorCode, adServerConfig.params);
+        }
+
       });
+
+      video.adServer
     });
 
     requestBids.before(enrichAdUnits, 40);

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -1,8 +1,9 @@
-import {config} from '../../src/config.js';
+import { config } from '../../src/config.js';
 import events from '../../src/events.js';
 import { allVideoEvents } from './constants/events.js';
 import CONSTANTS from '../../src/constants.json';
 import { videoCoreFactory } from './coreVideo.js';
+import { coreAdServerFactory } from './adServer.js';
 
 events.addEvents(allVideoEvents);
 
@@ -29,10 +30,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
         if (adServerConfig) {
           adServerCore.registerProvider(adServerConfig.vendorCode, adServerConfig.params);
         }
-
       });
-
-      video.adServer
     });
 
     requestBids.before(enrichAdUnits, 40);
@@ -41,6 +39,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
       // TODO: requires AdServer Module.
       // get ad tag from adServer - auctionResult.winningBids
       // coreVideo.setAdTagUrl(adTag, divId);
+      // const adTagUrl = adServerCore.getAdTagUrl();
     });
   }
 
@@ -58,7 +57,8 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
 
 function pbVideoFactory() {
   const videoCore = videoCoreFactory();
-  const pbVideo = PbVideo(videoCore, config.getConfig, $$PREBID_GLOBAL$$, events, allVideoEvents);
+  const adServerCore = coreAdServerFactory();
+  const pbVideo = PbVideo(videoCore, config.getConfig, $$PREBID_GLOBAL$$, events, allVideoEvents, adServerCore);
   pbVideo.init();
   return pbVideo;
 }

--- a/modules/videoModule/shared/parentModule.js
+++ b/modules/videoModule/shared/parentModule.js
@@ -30,7 +30,7 @@ export function ParentModule(submoduleBuilder_) {
   }
 }
 
-export function submoduleBuilder(submoduleDirectory_) {
+export function SubmoduleBuilder(submoduleDirectory_) {
   const submoduleDirectory = submoduleDirectory_;
 
   function build(id, config) {

--- a/modules/videoModule/shared/parentModule.js
+++ b/modules/videoModule/shared/parentModule.js
@@ -6,14 +6,19 @@ export function ParentModule(submoduleBuilder_) {
   const submoduleBuilder = submoduleBuilder_;
   const submodules = {};
 
-  function registerSubmodule(id, config) {
+  /*
+  id: identifies the submodule instance
+  vendorCode: identifies the submodule type that must be built
+  config: additional information necessary to instantiate the instance
+   */
+  function registerSubmodule(id, vendorCode, config) {
     if (submodules[id]) {
       return;
     }
 
     let submodule;
     try {
-      submodule = submoduleBuilder.build(id, config);
+      submodule = submoduleBuilder.build(vendorCode, config);
     } catch (e) {
       throw e;
     }
@@ -33,10 +38,10 @@ export function ParentModule(submoduleBuilder_) {
 export function SubmoduleBuilder(submoduleDirectory_) {
   const submoduleDirectory = submoduleDirectory_;
 
-  function build(id, config) {
-    const submoduleFactory = submoduleDirectory[id];
+  function build(vendorCode, config) {
+    const submoduleFactory = submoduleDirectory[vendorCode];
     if (!submoduleFactory) {
-      throw new Error('Unrecognized submodule code: ' + id);
+      throw new Error('Unrecognized submodule vendor code: ' + vendorCode);
     }
 
     const submodule = submoduleFactory(config);

--- a/modules/videoModule/shared/parentModule.js
+++ b/modules/videoModule/shared/parentModule.js
@@ -1,0 +1,50 @@
+
+/*
+Used by any module to manage the relationship with its submodules.
+ */
+export function ParentModule(submoduleBuilder_) {
+  const submoduleBuilder = submoduleBuilder_;
+  const submodules = {};
+
+  function registerSubmodule(id, config) {
+    if (submodules[id]) {
+      return;
+    }
+
+    let submodule;
+    try {
+      submodule = submoduleBuilder.build(id, config);
+    } catch (e) {
+      throw e;
+    }
+    submodules[id] = submodule;
+  }
+
+  function getSubmodule(id) {
+    return submodules[id];
+  }
+
+  return {
+    registerSubmodule,
+    getSubmodule
+  }
+}
+
+export function submoduleBuilder(submoduleDirectory_) {
+  const submoduleDirectory = submoduleDirectory_;
+
+  function build(id, config) {
+    const submoduleFactory = submoduleDirectory[id];
+    if (!submoduleFactory) {
+      throw new Error('Unrecognized submodule code: ' + id);
+    }
+
+    const submodule = submoduleFactory(config);
+    submodule && submodule.init && submodule.init();
+    return submodule;
+  }
+
+  return {
+    build
+  };
+}

--- a/modules/videoModule/vendorDirectory.js
+++ b/modules/videoModule/vendorDirectory.js
@@ -1,1 +1,2 @@
-export const vendorDirectory = {};
+export const videoVendorDirectory = {};
+export const adServerDirectory = {};

--- a/test/spec/modules/videoModule/adServer_spec.js
+++ b/test/spec/modules/videoModule/adServer_spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { AdServerCore } from 'modules/videoModule/adServer.js';
+
+describe('Ad Server Core', function () {
+  const parentModuleMock = {
+    registerSubmodule: sinon.spy(),
+    getSubmodule: sinon.spy()
+  };
+  const testVendorCode = 'test';
+  const adServerCore = AdServerCore(parentModuleMock);
+  adServerCore.registerAdServer({ vendorCode: testVendorCode });
+
+  describe('Register Ad Server', function () {
+    it('should use the vendor code as an id as well as a vendor code', function () {
+      expect(parentModuleMock.registerSubmodule.calledOnce).to.be.true;
+      expect(parentModuleMock.registerSubmodule.args[0][0]).to.be.equal(testVendorCode);
+      expect(parentModuleMock.registerSubmodule.args[0][1]).to.be.equal(testVendorCode);
+    });
+  });
+
+  describe('Get Ad Tag Url', function () {
+    it('should request the right submodule', function () {
+      adServerCore.getAdTagUrl(testVendorCode);
+      expect(parentModuleMock.getSubmodule.calledOnce).to.be.true;
+      expect(parentModuleMock.getSubmodule.args[0][0]).to.be.equal(testVendorCode);
+    });
+  });
+});

--- a/test/spec/modules/videoModule/coreVideo_spec.js
+++ b/test/spec/modules/videoModule/coreVideo_spec.js
@@ -1,7 +1,5 @@
 import { expect } from 'chai';
-import {
-  VideoCore
-} from 'modules/videoModule/coreVideo.js';
+import { VideoCore } from 'modules/videoModule/coreVideo.js';
 
 describe('Video Core', function () {
   const mockSubmodule = {

--- a/test/spec/modules/videoModule/pbVideo_spec.js
+++ b/test/spec/modules/videoModule/pbVideo_spec.js
@@ -8,6 +8,7 @@ let requestBidsMock;
 let pbGlobalMock;
 let pbEventsMock;
 let videoEventsMock;
+let adServerMock;
 
 function resetTestVars() {
   ortbParamsMock = {
@@ -17,29 +18,36 @@ function resetTestVars() {
   videoCoreMock = {
     registerProvider: sinon.spy(),
     onEvents: sinon.spy(),
-    getOrtbParams: () => ortbParamsMock
+    getOrtbParams: () => ortbParamsMock,
+    setAdTagUrl: sinon.spy()
   };
   getConfigMock = () => {};
   requestBidsMock = {
     before: sinon.spy()
   };
   pbGlobalMock = {
-    requestBids: requestBidsMock
+    requestBids: requestBidsMock,
+    getHighestCpmBids: sinon.spy()
   };
   pbEventsMock = {
     emit: sinon.spy(),
     on: sinon.spy()
   };
   videoEventsMock = [];
+  adServerMock = {
+    registerAdServer: sinon.spy(),
+    getAdTagUrl: sinon.spy()
+  };
 }
 
-let pbVideoFactory = (videoCore, getConfig, pbGlobal, pbEvents, videoEvents) => {
+let pbVideoFactory = (videoCore, getConfig, pbGlobal, pbEvents, videoEvents, adServer) => {
   const pbVideo = PbVideo(
     videoCore || videoCoreMock,
     getConfig || getConfigMock,
     pbGlobal || pbGlobalMock,
     pbEvents || pbEventsMock,
-    videoEvents || videoEventsMock
+    videoEvents || videoEventsMock,
+    adServer || adServerMock
   );
   pbVideo.init();
   return pbVideo;
@@ -87,6 +95,18 @@ describe('Prebid Video', function () {
         expect(pbEventsMock.emit.getCall(0).args[1]).to.be.equal(expectedPayload);
       });
     });
+
+    describe('Ad Server configuration', function() {
+      const test_vendor_code = 5;
+      const test_params = { test: 'params' };
+      providers[0].adServer = { vendorCode: test_vendor_code, params: test_params };
+
+      it('should register the ad server provider', function () {
+        expect(adServerMock.registerAdServer.calledOnce).to.be.true;
+        expect(adServerMock.registerAdServer.getCall(0).args[0]).to.be.equal(test_vendor_code);
+        expect(adServerMock.registerAdServer.getCall(0).args[1]).to.be.equal(test_params);
+      });
+    });
   });
 
   describe('Ad unit Enrichment', function () {
@@ -122,6 +142,51 @@ describe('Prebid Video', function () {
   });
 
   describe('Ad tag injection', function () {
-    // TODO: requires adServer to be implemented
+    let auctionEndCallback;
+    const pbEvents = {
+      emit: () => {},
+      on: (event, callback) => auctionEndCallback = callback
+    };
+
+    const expectedVendorCode = 5;
+    const expectedAdTag = 'test_tag';
+    const expectedAdUnit = {
+      video: {
+        adServer: {
+          vendorCode: expectedVendorCode,
+          baseAdTagUrl: expectedAdTag
+        }
+      }
+    };
+    const auctionResults = { adUnits: [ expectedAdUnit, {} ] };
+
+    it('should request ad tag url from adServer when configured to use adServer', function () {
+
+      pbVideoFactory(null, null, null, pbEvents);
+
+      auctionEndCallback(auctionResults);
+      expect(adServerMock.getAdTagUrl.calledOnce).to.be.true;
+      expect(adServerMock.getAdTagUrl.getCall(0).args[0]).is.equal(expectedVendorCode);
+      expect(adServerMock.getAdTagUrl.getCall(0).args[1]).is.equal(expectedAdUnit);
+      expect(adServerMock.getAdTagUrl.getCall(0).args[2]).is.equal(expectedAdTag);
+
+      expect(videoCoreMock.setAdTagUrl.called).to.be.false;
+    });
+
+    it('should load ad tag when ad server return ad tag', function () {
+      const expectedAdTag = 'resulting ad tag';
+      const adServerCore = {
+        getAdTagUrl: () => expectedAdTag,
+        registerAdServer: sinon.spy(),
+      };
+      pbVideoFactory(null, null, null, pbEvents, null, adServerCore);
+      auctionEndCallback(auctionResults);
+      expect(videoCoreMock.setAdTagUrl.calledOnce).to.be.true;
+      expect(videoCoreMock.setAdTagUrl.calledOnce.args[0][0]).to.be.equal(expectedAdTag);
+    });
+
+    it('should load ad tag from highest bid when ad server is not configured', function () {
+      
+    });
   });
 });

--- a/test/spec/modules/videoModule/shared/parentModule_spec.js
+++ b/test/spec/modules/videoModule/shared/parentModule_spec.js
@@ -2,8 +2,10 @@ import { SubmoduleBuilder, ParentModule } from 'modules/videoModule/shared/paren
 import { expect } from 'chai';
 
 describe('Parent Module', function() {
-  const vendorCodeForMock = 0;
-  const unrecognizedVendorCode = 999;
+  const idForMock = 0;
+  const vendorCodeForMock = 'a';
+  const unrecognizedId = 999;
+  const unrecognizedVendorCode = 'zzz';
   const mockSubmodule = { test: 'test' };
   const mockSubmoduleBuilder = {
     build: vendorCode => {
@@ -18,26 +20,19 @@ describe('Parent Module', function() {
 
   describe('Register Submodule', function () {
     it('should throw when the builder fails to build', function () {
-      // const flawedVideoCore = VideoCore({
-      //   build: () => {
-      //     throw new Error('flawed');
-      //   }
-      // });
-
-      expect(() => parentModule.registerSubmodule(unrecognizedVendorCode)).to.throw('flawed');
-      // expect(() => flawedVideoCore.registerProvider({ vendorCode: 0 })).to.throw('flawed');
+      expect(() => parentModule.registerSubmodule(unrecognizedId, unrecognizedVendorCode)).to.throw('flawed');
     });
   });
 
   describe('Get Submodule', function () {
     it('should return registered submodules', function () {
-      parentModule.registerSubmodule(vendorCodeForMock);
-      const submodule = parentModule.getSubmodule(vendorCodeForMock);
+      parentModule.registerSubmodule(idForMock, vendorCodeForMock);
+      const submodule = parentModule.getSubmodule(idForMock);
       expect(submodule).to.be.equal(mockSubmodule);
     });
 
     it('should return undefined when submodule is not registered', function () {
-      const submodule = parentModule.getSubmodule(unrecognizedVendorCode);
+      const submodule = parentModule.getSubmodule(unrecognizedId);
       expect(submodule).to.be.undefined;
     });
   })
@@ -73,6 +68,6 @@ describe('Submodule Builder', function () {
 
   it('should throw when vendor code is not recognized', function () {
     const unrecognizedVendorCode = 999;
-    expect(() => submoduleBuilder.build(unrecognizedVendorCode)).to.throw('Unrecognized submodule code: ' + unrecognizedVendorCode);
+    expect(() => submoduleBuilder.build(unrecognizedVendorCode)).to.throw('Unrecognized submodule vendor code: ' + unrecognizedVendorCode);
   });
 });

--- a/test/spec/modules/videoModule/shared/parentModule_spec.js
+++ b/test/spec/modules/videoModule/shared/parentModule_spec.js
@@ -1,0 +1,40 @@
+import { SubmoduleBuilder } from 'modules/videoModule/shared/parentModule.js';
+import { expect } from 'chai';
+
+describe('Parent Module', function() {
+
+});
+
+describe('Submodule Builder', function () {
+  const vendorCode1 = 1;
+  const vendorCode2 = 2;
+  const submodule1 = {};
+  const initSpy = sinon.spy();
+  const submodule2 = { init: initSpy };
+  const submoduleFactory1 = () => submodule1;
+  const submoduleFactory2 = () => submodule2;
+  const submoduleFactory1Spy = sinon.spy(submoduleFactory1);
+
+  const vendorDirectory = {};
+  vendorDirectory[vendorCode1] = submoduleFactory1Spy;
+  vendorDirectory[vendorCode2] = submoduleFactory2;
+
+  const submoduleBuilder = SubmoduleBuilder(vendorDirectory);
+
+  it('should call submodule factory when vendor code is supported', function () {
+    const submodule = submoduleBuilder.build(vendorCode1);
+    expect(submoduleFactory1Spy.calledOnce).to.be.true;
+    expect(submodule).to.be.equal(submodule1);
+  });
+
+  it('should instantiate the submodule, when supported', function () {
+    const submodule = submoduleBuilder.build(vendorCode2);
+    expect(initSpy.calledOnce).to.be.true;
+    expect(submodule).to.be.equal(submodule2);
+  });
+
+  it('should throw when vendor code is not recognized', function () {
+    const unrecognizedVendorCode = 999;
+    expect(() => submoduleBuilder.build(unrecognizedVendorCode)).to.throw('Unrecognized submodule code: ' + unrecognizedVendorCode);
+  });
+});

--- a/test/spec/modules/videoModule/shared/parentModule_spec.js
+++ b/test/spec/modules/videoModule/shared/parentModule_spec.js
@@ -1,8 +1,46 @@
-import { SubmoduleBuilder } from 'modules/videoModule/shared/parentModule.js';
+import { SubmoduleBuilder, ParentModule } from 'modules/videoModule/shared/parentModule.js';
 import { expect } from 'chai';
 
 describe('Parent Module', function() {
+  const vendorCodeForMock = 0;
+  const unrecognizedVendorCode = 999;
+  const mockSubmodule = { test: 'test' };
+  const mockSubmoduleBuilder = {
+    build: vendorCode => {
+      if (vendorCode === vendorCodeForMock) {
+        return mockSubmodule;
+      } else {
+        throw new Error('flawed');
+      }
+    }
+  };
+  const parentModule = ParentModule(mockSubmoduleBuilder);
 
+  describe('Register Submodule', function () {
+    it('should throw when the builder fails to build', function () {
+      // const flawedVideoCore = VideoCore({
+      //   build: () => {
+      //     throw new Error('flawed');
+      //   }
+      // });
+
+      expect(() => parentModule.registerSubmodule(unrecognizedVendorCode)).to.throw('flawed');
+      // expect(() => flawedVideoCore.registerProvider({ vendorCode: 0 })).to.throw('flawed');
+    });
+  });
+
+  describe('Get Submodule', function () {
+    it('should return registered submodules', function () {
+      parentModule.registerSubmodule(vendorCodeForMock);
+      const submodule = parentModule.getSubmodule(vendorCodeForMock);
+      expect(submodule).to.be.equal(mockSubmodule);
+    });
+
+    it('should return undefined when submodule is not registered', function () {
+      const submodule = parentModule.getSubmodule(unrecognizedVendorCode);
+      expect(submodule).to.be.undefined;
+    });
+  })
 });
 
 describe('Submodule Builder', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Adds ad server integration for the Video Module. 
- implements a simple module for GAM which uses the dfp module to build an ad tag url
- refactors core video to share code with core ad server
- when the auction ends:
- - if an ad server is specified, it is asked to create an ad tag url which is then passed to the core video module.
- - if no ad server is specified, the highest bid's vast url and vast xml are provided to the player

