### PR TITLE
GRO-382 | Encode url query paraams

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1187,8 +1187,8 @@ export function formatQS(query) {
   return Object
     .keys(query)
     .map(k => Array.isArray(query[k])
-      ? query[k].map(v => `${k}[]=${v}`).join('&')
-      : `${k}=${query[k]}`)
+      ? query[k].map(v => `${k}[]=${encodeURIComponent(v)}`).join('&')
+      : `${k}=${encodeURIComponent(query[k])}`)
     .join('&');
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
* Update one of the query string formatting functions fixing [GRO-328](https://jwplayer.atlassian.net/browse/GRO-382)


## Notes

* Debugging notes: https://gist.github.com/JoshuaRogan/0bad8da99f348d8fcaadf44c7555c263
* PR was only tested in an isolated way (see gist)

It appears there are multiple query string formatting functions 

https://github.com/jwplayer/Prebid.js/blob/master/src/utils.js#L135
https://github.com/jwplayer/Prebid.js/blob/master/src/utils.js#L1186 – doesn’t use `encodeURIComponent`

Unsure why there are multiple of these functions and wonder if we should migrate it all to `URLSearchParams` [Docs](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)





